### PR TITLE
Force network order on all pack/unpack operations

### DIFF
--- a/pybinn/__init__.py
+++ b/pybinn/__init__.py
@@ -1,6 +1,6 @@
 """BINN (https://github.com/liteserver/binn) serialization/deserialization module"""
 
-__version__ = '0.9.5'
+__version__ = '0.9.7'
 __all__ = [
     'dumps', 'loads', 'dump', 'load',
     'BINNDecoder', 'BINNEncoder',

--- a/pybinn/decoder.py
+++ b/pybinn/decoder.py
@@ -23,25 +23,25 @@ class BINNDecoder(object):
         if binntype == types.BINN_STRING:
             return self._decode_str()
         if binntype == types.BINN_UINT8:
-            return unpack('B', self._buffer.read(1))[0]
+            return unpack('!B', self._buffer.read(1))[0]
         if binntype == types.BINN_INT8:
-            return unpack('b', self._buffer.read(1))[0]
+            return unpack('!b', self._buffer.read(1))[0]
         if binntype == types.BINN_UINT16:
-            return unpack('H', self._buffer.read(2))[0]
+            return unpack('!H', self._buffer.read(2))[0]
         if binntype == types.BINN_INT16:
-            return unpack('h', self._buffer.read(2))[0]
+            return unpack('!h', self._buffer.read(2))[0]
         if binntype == types.BINN_UINT32:
-            return unpack('I', self._buffer.read(4))[0]
+            return unpack('!I', self._buffer.read(4))[0]
         if binntype == types.BINN_INT32:
-            return unpack('i', self._buffer.read(4))[0]
+            return unpack('!i', self._buffer.read(4))[0]
         if binntype == types.BINN_FLOAT32:
-            return unpack('f', self._buffer.read(4))[0]
+            return unpack('!f', self._buffer.read(4))[0]
         if binntype == types.BINN_UINT64:
-            return unpack('Q', self._buffer.read(8))[0]
+            return unpack('!Q', self._buffer.read(8))[0]
         if binntype == types.BINN_INT64:
-            return unpack('q', self._buffer.read(8))[0]
+            return unpack('!q', self._buffer.read(8))[0]
         if binntype == types.BINN_FLOAT64:
-            return unpack('d', self._buffer.read(8))[0]
+            return unpack('!d', self._buffer.read(8))[0]
         if binntype == types.BINN_BLOB:
             return self._decode_bytes()
         if binntype == types.BINN_DATETIME:
@@ -75,11 +75,11 @@ class BINNDecoder(object):
         return value
 
     def _decode_bytes(self):
-        size = unpack('I', self._buffer.read(4))[0]
+        size = unpack('!I', self._buffer.read(4))[0]
         return self._buffer.read(size)
 
     def _decode_datetime(self):
-        timestamp = float(unpack('d', self._buffer.read(8))[0])
+        timestamp = float(unpack('!d', self._buffer.read(8))[0])
         # datetime.utcfromtimestamp method in python3.3 has rounding issue (https://bugs.python.org/issue23517)
         return datetime(1970, 1, 1) + timedelta(seconds=timestamp)
 
@@ -99,10 +99,10 @@ class BINNDecoder(object):
         result = {}
         for i in range(count):
             if binntype == types.BINN_OBJECT:
-                key_size = unpack('B', self._buffer.read(1))[0]
+                key_size = unpack('!B', self._buffer.read(1))[0]
                 key = self._buffer.read(key_size).decode('utf8')
             if binntype == types.BINN_MAP:
-                key = unpack('I', self._buffer.read(4))[0]
+                key = unpack('!I', self._buffer.read(4))[0]
             if binntype == types.PYBINN_MAP:
                 key = self._buffer.read(types.PYBINN_MAP_SIZE)
             result[key] = self.decode()
@@ -113,10 +113,10 @@ class BINNDecoder(object):
         return decoder.getobject(self._buffer.read(size))
 
     def _from_varint(self):
-        value = unpack('B', self._buffer.read(1))[0]
+        value = unpack('!B', self._buffer.read(1))[0]
         if value & 0x80:
             self._buffer.seek(self._buffer.tell() - 1)
-            value = unpack('>I', self._buffer.read(4))[0]
+            value = unpack('!I', self._buffer.read(4))[0]
             value &= 0x7FFFFFFF
         return value
 

--- a/pybinn/encoder.py
+++ b/pybinn/encoder.py
@@ -71,22 +71,22 @@ class BINNEncoder(object):
         # unsigned char (byte)
         if value < 0x100:
             self._buffer.write(types.BINN_UINT8)
-            self._buffer.write(pack('B', value))
+            self._buffer.write(pack('!B', value))
             return
         # unsigned short
         if value < 0x10000:
             self._buffer.write(types.BINN_UINT16)
-            self._buffer.write(pack('H', value))
+            self._buffer.write(pack('!H', value))
             return
         # unsigned int
         if value < 0x100000000:
             self._buffer.write(types.BINN_UINT32)
-            self._buffer.write(pack('I', value))
+            self._buffer.write(pack('!I', value))
             return
         # unsigned long
         if value < 0x10000000000000000:
             self._buffer.write(types.BINN_UINT64)
-            self._buffer.write(pack('Q', value))
+            self._buffer.write(pack('!Q', value))
             return
         raise OverflowError("Value to big {}.".format(hex(value)))
 
@@ -96,22 +96,22 @@ class BINNEncoder(object):
         # signed char
         if value >= -0x80:
             self._buffer.write(types.BINN_INT8)
-            self._buffer.write(pack('b', value))
+            self._buffer.write(pack('!b', value))
             return
         # short
         if value >= -0x8000:
             self._buffer.write(types.BINN_INT16)
-            self._buffer.write(pack('h', value))
+            self._buffer.write(pack('!h', value))
             return
         # int
         if value >= -0x80000000:
             self._buffer.write(types.BINN_INT32)
-            self._buffer.write(pack('i', value))
+            self._buffer.write(pack('!i', value))
             return
         # long
         if value >= -0x8000000000000000:
             self._buffer.write(types.BINN_INT64)
-            self._buffer.write(pack('q', value))
+            self._buffer.write(pack('!q', value))
 
     def _encode_bool(self, value):
         if value:
@@ -123,11 +123,11 @@ class BINNEncoder(object):
         if binn_type is None:
             binn_type = types.BINN_FLOAT64
         self._buffer.write(binn_type)
-        self._buffer.write(pack('d', value))
+        self._buffer.write(pack('!d', value))
 
     def _encode_bytes(self, value):
         self._buffer.write(types.BINN_BLOB)
-        self._buffer.write(pack('I', len(value)))
+        self._buffer.write(pack('!I', len(value)))
         self._buffer.write(value)
 
     def _encode_datetime(self, value):
@@ -153,12 +153,12 @@ class BINNEncoder(object):
                 if isinstance(key, str):
                     if len(key) > 255:
                         raise OverflowError("Key '{}' is to big. Max length is 255.".format(key))
-                    buffer.write(pack('B', len(key)))
+                    buffer.write(pack('!B', len(key)))
                     buffer.write(key.encode('utf8'))
                     buffer.write(BINNEncoder().encode_bytes(value[key]))
                 elif isinstance(key, int):
                     container_type = types.BINN_MAP
-                    buffer.write(pack('I', key))
+                    buffer.write(pack('!I', key))
                     buffer.write(BINNEncoder().encode_bytes(value[key]))
                 elif isinstance(key, bytes):
                     if len(key) != types.PYBINN_MAP_SIZE:
@@ -185,8 +185,8 @@ class BINNEncoder(object):
     @staticmethod
     def _to_varint(value):
         if value > 127:
-            return pack('>I', value | 0x80000000)
-        return pack('B', value)
+            return pack('!I', value | 0x80000000)
+        return pack('!B', value)
 
 
 class CustomEncoder(object):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name="pybinn",
-      version="0.9.6",
+      version="0.9.7",
       description="Python 3.x wrapper for BINN serialization format",
       author="Miron Jakubowski",
       author_email="mijakubowski@gmail.com",


### PR DESCRIPTION
This patch just adds the "!" prefix to every packing operations, this should solve #4 and issues with endianess.

Usage of prefix "!" is specified here: https://docs.python.org/3/library/struct.html#byte-order-size-and-alignment